### PR TITLE
Fixed searching for "zombies" with Bing.

### DIFF
--- a/core/main.py
+++ b/core/main.py
@@ -1320,7 +1320,7 @@ class UFONet(object):
         if not options.engine or options.engine == 'bing': # using bing by default [27/06/2017: OK!]
             if not options.engine:
                 options.engine = 'bing'
-            url = 'https://www.bing.com/search?'
+            url = 'https://www.bing.com/?scope'
             if options.search: # search from query
                 q = 'instreamset:(url):"' + str(options.search) + '"' # set query to search literally on results
             if options.dorks or options.autosearch: # search from a dork


### PR DESCRIPTION
When searching for ¨zombies¨ it commonly says: `<[Error] Something went wrong with searching: Bing>` 

The URL redirects to your country based on IP With the new URL [https://www.bing.com/?scope](https://www.bing.com/?scope) this fixes it.

![ufonet-searching-for-zombies-fix](https://user-images.githubusercontent.com/7843719/35125647-0a62a95c-fc70-11e7-8852-e0a6b68791d4.gif)
